### PR TITLE
Tickets/dm 28811

### DIFF
--- a/python/lsst/ts/adamSensors/__init__.py
+++ b/python/lsst/ts/adamSensors/__init__.py
@@ -25,4 +25,4 @@ except ImportError:
 from .adamSensorsCSC import *
 from .mockModbus import *
 from .config_schema import *
-from .model import * 
+from .model import *

--- a/python/lsst/ts/adamSensors/__init__.py
+++ b/python/lsst/ts/adamSensors/__init__.py
@@ -18,3 +18,6 @@
 #
 # You should have received a copy of the GNU General Public License
 from .adamSensorsCSC import *
+from .mockModbus import *
+from .config_schema import *
+from .model import * 

--- a/python/lsst/ts/adamSensors/__init__.py
+++ b/python/lsst/ts/adamSensors/__init__.py
@@ -17,6 +17,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
+try:
+    from .version import *
+except ImportError:
+    __version__ = "?"
+
 from .adamSensorsCSC import *
 from .mockModbus import *
 from .config_schema import *

--- a/python/lsst/ts/adamSensors/adamSensorsCSC.py
+++ b/python/lsst/ts/adamSensors/adamSensorsCSC.py
@@ -92,13 +92,10 @@ class AdamCSC(salobj.ConfigurableCsc):
 
         self.log.debug("hasPressure = " + str(hasPressure))
 
-        loop = asyncio.get_event_loop()
-        executor = concurrent.futures.ThreadPoolExecutor()
-
         outputs = [0, 0, 0, 0, 0, 0]
         self.log.debug("about to start telemetry loop")
         while True:
-            voltages = await loop.run_in_executor(executor, self.adam.read_voltage)
+            voltages = await self.adam.read_voltage
 
             # convert the voltage into whatever units, according to the
             # polynomial defined in configuration

--- a/python/lsst/ts/adamSensors/adamSensorsCSC.py
+++ b/python/lsst/ts/adamSensors/adamSensorsCSC.py
@@ -45,7 +45,7 @@ class AdamCSC(salobj.ConfigurableCsc):
             await self.adam.connect(self.config.adam_ip, self.config.adam_port)
         except ConnectionException:
             raise RuntimeError(
-                f"Unable to connect to modbus device at "
+                "Unable to connect to modbus device at "
                 f"{self.config.adam_ip}:{self.config.adam_port}."
             )
         if self.telemetry_loop_task.result() is not None:

--- a/python/lsst/ts/adamSensors/adamSensorsCSC.py
+++ b/python/lsst/ts/adamSensors/adamSensorsCSC.py
@@ -43,7 +43,8 @@ class AdamCSC(salobj.ConfigurableCsc):
         try:
             await self.adam.connect(self.config.adam_ip, self.config.adam_port)
         except ConnectionException:
-            self.fault(code=2, report="Unable to connect to modbus device at " + str(self.config.adam_ip))
+            raise RuntimeError(f"Unable to connect to modbus device at {self.config.adam_ip}:\
+                {self.config.adam_port}.")
         if self.telemetry_loop_task.result() is not None:
             self.telemetry_loop_task.cancel()
         self.telemetry_loop_task = asyncio.create_task(self.telemetry_loop())
@@ -54,8 +55,11 @@ class AdamCSC(salobj.ConfigurableCsc):
         cancels the telemetry loop task and disconnects from the ADAM
         device.
         """
-        self.telemetry_loop_task.cancel()
-        await self.model.disconnect()
+        try:
+            self.telemetry_loop_task.cancel()
+            await self.model.disconnect()
+        except:
+            pass
 
     async def telemetry_loop(self):
         """

--- a/python/lsst/ts/adamSensors/config_schema.py
+++ b/python/lsst/ts/adamSensors/config_schema.py
@@ -25,7 +25,9 @@ properties:
     type: string
     default: "None"
   analog_input_0_coefficients:
-    description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
+    description: >-
+      list of numbers defining, in descending order, the terms of a polynomial that maps voltages
+      to the appropriate units. A value of [1., 0] here is a 1:1 linear mapping of volts to whatever.
     type: array
     items:
       type: number
@@ -35,7 +37,9 @@ properties:
     type: string
     default: "None"
   analog_input_1_coefficients:
-    description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
+    description: >-
+      list of numbers defining, in descending order, the terms of a polynomial that maps voltages
+      to the appropriate units. A value of [1., 0] here is a 1:1 linear mapping of volts to whatever.
     type: array
     items:
       type: number
@@ -45,7 +49,9 @@ properties:
     type: string
     default: "None"
   analog_input_2_coefficients:
-    description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
+    description: >-
+      list of numbers defining, in descending order, the terms of a polynomial that maps voltages
+      to the appropriate units. A value of [1., 0] here is a 1:1 linear mapping of volts to whatever.
     type: array
     items:
       type: number
@@ -55,7 +61,9 @@ properties:
     type: string
     default: "None"
   analog_input_3_coefficients:
-    description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
+    description: >-
+      list of numbers defining, in descending order, the terms of a polynomial that maps voltages
+      to the appropriate units. A value of [1., 0] here is a 1:1 linear mapping of volts to whatever.
     type: array
     items:
       type: number
@@ -65,7 +73,9 @@ properties:
     type: string
     default: "None"
   analog_input_4_coefficients:
-    description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
+    description: >-
+      list of numbers defining, in descending order, the terms of a polynomial that maps voltages
+      to the appropriate units. A value of [1., 0] here is a 1:1 linear mapping of volts to whatever.
     type: array
     items:
       type: number
@@ -75,7 +85,9 @@ properties:
     type: string
     default: "None"
   analog_input_5_coefficients:
-    description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
+    description: >-
+      list of numbers defining, in descending order, the terms of a polynomial that maps voltages
+      to the appropriate units. A value of [1., 0] here is a 1:1 linear mapping of volts to whatever.
     type: array
     items:
       type: number

--- a/python/lsst/ts/adamSensors/config_schema.py
+++ b/python/lsst/ts/adamSensors/config_schema.py
@@ -1,3 +1,10 @@
+__all__ = ["CONFIG_SCHEMA"]
+
+import yaml
+
+
+CONFIG_SCHEMA = yaml.safe_load(
+    """
 $schema: http://json-schema.org/draft-07/schema#
 $id: https://github.com/lsst-ts/ts_adamSensors/blob/master/schema/AdamSensors.yaml
 # title must end with one or more spaces followed by the schema version, which must begin with "v"
@@ -21,7 +28,7 @@ properties:
     description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
     type: array
     items:
-      type: float
+      type: number
     default: [1., 0.]
   analog_input_1_type:
     description: Type of sensor connected to ADAM AO-1. Can be "None", "Temperature", or "Pressure".
@@ -31,7 +38,7 @@ properties:
     description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
     type: array
     items:
-      type: float
+      type: number
     default: [1., 0.]
   analog_input_2_type:
     description: Type of sensor connected to ADAM AO-2. Can be "None", "Temperature", or "Pressure".
@@ -41,7 +48,7 @@ properties:
     description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
     type: array
     items:
-      type: float
+      type: number
     default: [1., 0.]
   analog_input_3_type:
     description: Type of sensor connected to ADAM AO-3. Can be "None", "Temperature", or "Pressure".
@@ -51,7 +58,7 @@ properties:
     description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
     type: array
     items:
-      type: float
+      type: number
     default: [344738., 0.]
   analog_input_4_type:
     description: Type of sensor connected to ADAM AO-4. Can be "None", "Temperature", or "Pressure".
@@ -61,7 +68,7 @@ properties:
     description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
     type: array
     items:
-      type: float
+      type: number
     default: [1., 0.]
   analog_input_5_type:
     description: Type of sensor connected to ADAM AO-5. Can be "None", "Temperature", or "Pressure".
@@ -71,5 +78,7 @@ properties:
     description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
     type: array
     items:
-      type: float
-    default: [344738., 0.]
+      type: number
+    default: [344738., 0.]"""
+)
+"""Configuration schema as a constant."""

--- a/python/lsst/ts/adamSensors/config_schema.py
+++ b/python/lsst/ts/adamSensors/config_schema.py
@@ -93,4 +93,3 @@ properties:
       type: number
     default: [344738., 0.]"""
 )
-"""Configuration schema as a constant."""

--- a/python/lsst/ts/adamSensors/mockModbus.py
+++ b/python/lsst/ts/adamSensors/mockModbus.py
@@ -24,7 +24,7 @@ class MockModbusClient:
         """
 
         Fake_readout = namedtuple("Fake_readout", ["registers"])
-        f = Fake_readout(registers=[sin(time() % 1 / 10) * 10, 0, -10, 10, -1.25, 3.14])
+        f = Fake_readout(registers=[sin(time() / 10) * 10, 0, -10, 10, -1.25, 3.14])
 
         return f
 

--- a/python/lsst/ts/adamSensors/mockModbus.py
+++ b/python/lsst/ts/adamSensors/mockModbus.py
@@ -23,7 +23,7 @@ class MockModbusClient():
                  the adam device.
         """
 
-        Fake_readout = namedtuple('Fake_readout', ['registers']) 
+        Fake_readout = namedtuple('Fake_readout', ['registers'])
         f = Fake_readout(registers=[sin(time()/10)*10, 0, -10, 10, -1.25, 3.14])
 
         return f

--- a/python/lsst/ts/adamSensors/mockModbus.py
+++ b/python/lsst/ts/adamSensors/mockModbus.py
@@ -1,0 +1,32 @@
+from time import time
+from math import sin
+from collections import namedtuple
+
+
+class MockModbusClient():
+    def __init__(self, client, port):
+        pass
+
+    async def read_input_registers(self, address, count=1, unit=1):
+        """
+        Mock version of pymodbus class that reads voltages
+        off of the ADAM 6024's analog inputs. The first one
+        is a sine wave based on time.time(), the rest are
+        static. -10 and 10 represent the minimum and maximum
+        values we ever expect to see from the ADAM 6024.
+
+        Parameters:
+        -----------
+        address: starting point of the range we want to read.
+                 for the ADAM 6024, always zero.
+        count:   number of sequential values to read from
+                 the adam device.
+        """
+
+        Fake_readout = namedtuple('Fake_readout', ['registers']) 
+        f = Fake_readout(registers=[sin(time()/10)*10, 0, -10, 10, -1.25, 3.14])
+
+        return f
+
+    async def close(self):
+        pass

--- a/python/lsst/ts/adamSensors/mockModbus.py
+++ b/python/lsst/ts/adamSensors/mockModbus.py
@@ -3,7 +3,7 @@ from math import sin
 from collections import namedtuple
 
 
-class MockModbusClient():
+class MockModbusClient:
     def __init__(self, client, port):
         pass
 
@@ -23,8 +23,8 @@ class MockModbusClient():
                  the adam device.
         """
 
-        Fake_readout = namedtuple('Fake_readout', ['registers'])
-        f = Fake_readout(registers=[sin(time()%1/10)*10, 0, -10, 10, -1.25, 3.14])
+        Fake_readout = namedtuple("Fake_readout", ["registers"])
+        f = Fake_readout(registers=[sin(time() % 1 / 10) * 10, 0, -10, 10, -1.25, 3.14])
 
         return f
 

--- a/python/lsst/ts/adamSensors/mockModbus.py
+++ b/python/lsst/ts/adamSensors/mockModbus.py
@@ -24,7 +24,7 @@ class MockModbusClient():
         """
 
         Fake_readout = namedtuple('Fake_readout', ['registers'])
-        f = Fake_readout(registers=[sin(time()/10)*10, 0, -10, 10, -1.25, 3.14])
+        f = Fake_readout(registers=[sin(time()%1/10)*10, 0, -10, 10, -1.25, 3.14])
 
         return f
 

--- a/python/lsst/ts/adamSensors/model.py
+++ b/python/lsst/ts/adamSensors/model.py
@@ -44,7 +44,8 @@ class AdamModel:
             try:
                 self.client = ModbusClient(self.clientip, self.clientport)
             except AttributeError:
-                raise ConnectionException
+                raise ConnectionException(f"Unable to connect to modbus device at {self.clientip}:\
+                    {self.clientport}")
 
     async def disconnect(self):
         await self.client.close()
@@ -76,7 +77,8 @@ class AdamModel:
             # may see a fix in a future version, which may require
             # minor code changes on our part.
             # https://github.com/riptideio/pymodbus/issues/298
-            raise ConnectionException
+            raise ConnectionException(f"Unable to reach modbus device at {self.clientip}:\
+                    {self.clientport}")
 
     def counts_to_volts(self, counts):
         """converts discrete ADAM-6024 input readings into volts

--- a/python/lsst/ts/adamSensors/model.py
+++ b/python/lsst/ts/adamSensors/model.py
@@ -1,5 +1,6 @@
-from pymodbus.client.sync import ModbusTcpClient as ModbusClient
+from pymodbus.client.asynchronous.tcp import AsyncModbusTCPClient as ModbusClient
 from pymodbus.exceptions import ConnectionException
+from mockModbus import MockModbusClient
 import logging
 
 
@@ -34,18 +35,18 @@ class AdamModel:
         self.range_start = -10  # zero point offset for the ADAM device
         self.simulation_mode = simulation_mode
 
-    def connect(self, ip, port):
+    async def connect(self, ip, port):
         self.clientip = ip
         self.clientport = port
         if self.simulation_mode:
-            self.client = None
+            self.client = MockModbusClient(self.clientip, self.clientporty)
         else:
             self.client = ModbusClient(self.clientip, self.clientport)
 
-    def disconnect(self):
-        self.client.close()
+    async def disconnect(self):
+        await self.client.close()
 
-    def read_voltage(self):
+    async def read_voltage(self):
         """reads the voltage off of ADAM-6024's inputs for channels 0-5.
 
         Parameters
@@ -57,25 +58,22 @@ class AdamModel:
         volts : List of floats
             the voltages on the ADAM's input channels
         """
-        if self.simulation_mode:
-            return [0, 0, 0, 0, 0, 1.25]
-
-        else:
-            try:
-                readout = self.client.read_input_registers(0, 8, unit=1)
-                return [self.counts_to_volts(r) for r in readout.registers]
-            except AttributeError:
-                # read_input_registers() *returns* (not raises) a
-                # ModbusIOException in the event of loss of ADAM network
-                # connectivity, which causes an AttributeError when we try
-                # to access the registers field. But the whole thing is
-                # really a connectivity problem, so we re-raise it as a
-                # ConnectionException, which we know how to handle. Weird
-                # exception handling is a known issue with pymodbus so it
-                # may see a fix in a future version, which may require
-                # minor code changes on our part.
-                # https://github.com/riptideio/pymodbus/issues/298
-                raise ConnectionException
+       
+        try:
+            readout = self.client.read_input_registers(0, 8, unit=1)
+            return [self.counts_to_volts(r) for r in readout.registers]
+        except AttributeError:
+            # read_input_registers() *returns* (not raises) a
+            # ModbusIOException in the event of loss of ADAM network
+            # connectivity, which causes an AttributeError when we try
+            # to access the registers field. But the whole thing is
+            # really a connectivity problem, so we re-raise it as a
+            # ConnectionException, which we know how to handle. Weird
+            # exception handling is a known issue with pymodbus so it
+            # may see a fix in a future version, which may require
+            # minor code changes on our part.
+            # https://github.com/riptideio/pymodbus/issues/298
+            raise ConnectionException
 
     def counts_to_volts(self, counts):
         """converts discrete ADAM-6024 input readings into volts

--- a/python/lsst/ts/adamSensors/model.py
+++ b/python/lsst/ts/adamSensors/model.py
@@ -41,7 +41,10 @@ class AdamModel:
         if self.simulation_mode:
             self.client = MockModbusClient(self.clientip, self.clientport)
         else:
-            self.client = ModbusClient(self.clientip, self.clientport)
+            try:
+                self.client = ModbusClient(self.clientip, self.clientport)
+            except AttributeError:
+                raise ConnectionException
 
     async def disconnect(self):
         await self.client.close()

--- a/python/lsst/ts/adamSensors/model.py
+++ b/python/lsst/ts/adamSensors/model.py
@@ -45,8 +45,8 @@ class AdamModel:
                 self.client = ModbusClient(self.clientip, self.clientport)
             except AttributeError:
                 raise ConnectionException(
-                    f"Unable to connect to modbus device at {self.clientip}:\
-                    {self.clientport}"
+                    "Unable to connect to modbus device at "
+                    f"{self.clientip}:{self.clientport}."
                 )
 
     async def disconnect(self):
@@ -80,8 +80,8 @@ class AdamModel:
             # minor code changes on our part.
             # https://github.com/riptideio/pymodbus/issues/298
             raise ConnectionException(
-                f"Unable to reach modbus device at {self.clientip}:\
-                    {self.clientport}"
+                f"Unable to reach modbus device at "
+                f"{self.clientip}:{self.clientport}."
             )
 
     def counts_to_volts(self, counts):

--- a/python/lsst/ts/adamSensors/model.py
+++ b/python/lsst/ts/adamSensors/model.py
@@ -1,6 +1,6 @@
 from pymodbus.client.asynchronous.tcp import AsyncModbusTCPClient as ModbusClient
 from pymodbus.exceptions import ConnectionException
-from mockModbus import MockModbusClient
+from .mockModbus import MockModbusClient
 import logging
 
 
@@ -39,7 +39,7 @@ class AdamModel:
         self.clientip = ip
         self.clientport = port
         if self.simulation_mode:
-            self.client = MockModbusClient(self.clientip, self.clientporty)
+            self.client = MockModbusClient(self.clientip, self.clientport)
         else:
             self.client = ModbusClient(self.clientip, self.clientport)
 
@@ -58,9 +58,9 @@ class AdamModel:
         volts : List of floats
             the voltages on the ADAM's input channels
         """
-       
+
         try:
-            readout = self.client.read_input_registers(0, 8, unit=1)
+            readout = await self.client.read_input_registers(0, 8, unit=1)
             return [self.counts_to_volts(r) for r in readout.registers]
         except AttributeError:
             # read_input_registers() *returns* (not raises) a

--- a/python/lsst/ts/adamSensors/model.py
+++ b/python/lsst/ts/adamSensors/model.py
@@ -44,8 +44,10 @@ class AdamModel:
             try:
                 self.client = ModbusClient(self.clientip, self.clientport)
             except AttributeError:
-                raise ConnectionException(f"Unable to connect to modbus device at {self.clientip}:\
-                    {self.clientport}")
+                raise ConnectionException(
+                    f"Unable to connect to modbus device at {self.clientip}:\
+                    {self.clientport}"
+                )
 
     async def disconnect(self):
         await self.client.close()
@@ -77,8 +79,10 @@ class AdamModel:
             # may see a fix in a future version, which may require
             # minor code changes on our part.
             # https://github.com/riptideio/pymodbus/issues/298
-            raise ConnectionException(f"Unable to reach modbus device at {self.clientip}:\
-                    {self.clientport}")
+            raise ConnectionException(
+                f"Unable to reach modbus device at {self.clientip}:\
+                    {self.clientport}"
+            )
 
     def counts_to_volts(self, counts):
         """converts discrete ADAM-6024 input readings into volts

--- a/schema/AdamSensors.yaml
+++ b/schema/AdamSensors.yaml
@@ -20,6 +20,8 @@ properties:
   analog_input_0_coefficients:
     description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
     type: array
+    items:
+      type: float
     default: [1, 0]
   analog_input_1_type:
     description: Type of sensor connected to ADAM AO-1. Can be "None", "Temperature", or "Pressure".
@@ -28,6 +30,8 @@ properties:
   analog_input_1_coefficients:
     description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
     type: array
+    items:
+      type: float
     default: [1, 0]
   analog_input_2_type:
     description: Type of sensor connected to ADAM AO-2. Can be "None", "Temperature", or "Pressure".
@@ -36,6 +40,8 @@ properties:
   analog_input_2_coefficients:
     description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
     type: array
+    items:
+      type: float
     default: [1, 0]
   analog_input_3_type:
     description: Type of sensor connected to ADAM AO-3. Can be "None", "Temperature", or "Pressure".
@@ -44,6 +50,8 @@ properties:
   analog_input_3_coefficients:
     description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
     type: array
+    items:
+      type: float
     default: [344738, 0]
   analog_input_4_type:
     description: Type of sensor connected to ADAM AO-4. Can be "None", "Temperature", or "Pressure".
@@ -52,6 +60,8 @@ properties:
   analog_input_4_coefficients:
     description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
     type: array
+    items:
+      type: float
     default: [1, 0]
   analog_input_5_type:
     description: Type of sensor connected to ADAM AO-5. Can be "None", "Temperature", or "Pressure".
@@ -60,4 +70,6 @@ properties:
   analog_input_5_coefficients:
     description: list of numbers defining, in descending order, the terms of a polynomial that maps voltages to the appropriate units
     type: array
+    items:
+      type: float
     default: [344738, 0]

--- a/schema/AdamSensors.yaml
+++ b/schema/AdamSensors.yaml
@@ -22,7 +22,7 @@ properties:
     type: array
     items:
       type: float
-    default: [1, 0]
+    default: [1., 0.]
   analog_input_1_type:
     description: Type of sensor connected to ADAM AO-1. Can be "None", "Temperature", or "Pressure".
     type: string
@@ -32,7 +32,7 @@ properties:
     type: array
     items:
       type: float
-    default: [1, 0]
+    default: [1., 0.]
   analog_input_2_type:
     description: Type of sensor connected to ADAM AO-2. Can be "None", "Temperature", or "Pressure".
     type: string
@@ -42,7 +42,7 @@ properties:
     type: array
     items:
       type: float
-    default: [1, 0]
+    default: [1., 0.]
   analog_input_3_type:
     description: Type of sensor connected to ADAM AO-3. Can be "None", "Temperature", or "Pressure".
     type: string
@@ -52,7 +52,7 @@ properties:
     type: array
     items:
       type: float
-    default: [344738, 0]
+    default: [344738., 0.]
   analog_input_4_type:
     description: Type of sensor connected to ADAM AO-4. Can be "None", "Temperature", or "Pressure".
     type: string
@@ -62,7 +62,7 @@ properties:
     type: array
     items:
       type: float
-    default: [1, 0]
+    default: [1., 0.]
   analog_input_5_type:
     description: Type of sensor connected to ADAM AO-5. Can be "None", "Temperature", or "Pressure".
     type: string
@@ -72,4 +72,4 @@ properties:
     type: array
     items:
       type: float
-    default: [344738, 0]
+    default: [344738., 0.]

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -24,7 +24,7 @@ class CscTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
             simulation_mode=1,
         ):
             await self.remote.cmd_start.set_start(
-                settingsToApply="homeoffice_pandemic_test.yaml"
+                settingsToApply="initial_test_config.yaml"
             )
 
 


### PR DESCRIPTION
- Now uses asyncio-enabled pymodbus library rather than synchronous version.
- Implements connection exception handling based on the way it works in ATWhiteLight (which uses the same modbus hardware, but hasn't yet implemented the newer asyncio-friendly pymodbus. As far as I know, it should report the same exceptions though.) ADAM hardware is in transit to Chile, will want to test that it behaves as expected once it arrives. 
- If we attempt to start the telemetry loop task and an existing telemetry loop task is already running, we now cancel the old task and start a fresh one.
- Adds more robust simulation mode, including a sine wave based on the current time on one of the channels, so we will have dynamic telemetry available in simulation mode rather than just constant values.
- Fixed simulation mode warning (needed to be a tuple, not a list)
- yaml schema is now encapsulated in config_schema.py rather than a .yaml file, as recommended by latest salobj.
- Now gracefully cancels telemetry task when we go to standby 